### PR TITLE
帮朋友弄的高亮主题

### DIFF
--- a/source/css/SimpleStyle.css
+++ b/source/css/SimpleStyle.css
@@ -3147,7 +3147,6 @@ body.night-mode,.night-mode .btn,body.night-mode a,.night-mode .nav-user a,#sear
 }
 .markdown-body table tr {
     background-color:#fff;
-    border-top:1px solid #ccc
 }
 .markdown-body table tr:nth-child(2n) {
     background-color:#f8f8f8
@@ -3242,65 +3241,263 @@ body.night-mode,.night-mode .btn,body.night-mode a,.night-mode .nav-user a,#sear
     overflow:hidden;
     text-align:right
 }
-.markdown-body code,.markdown-body tt {
-    padding:0;
-    padding-top:.2em;
-    padding-bottom:.2em;
-    margin:0;
-    font-size:85%;
-    background-color:rgba(0,0,0,0.04);
-    border-radius:3px
-}
-.markdown-body code::before,.markdown-body code::after,.markdown-body tt::before,.markdown-body tt::after {
-    letter-spacing:-0.2em;
-    content:"\00a0"
-}
-.markdown-body code br,.markdown-body tt br {
-    display:none
-}
-.markdown-body del code {
-    text-decoration:inherit
-}
-.markdown-body pre {
-    word-wrap:normal
-}
-.markdown-body pre>code {
-    padding:0;
-    margin:0;
-    font-size:100%;
-    word-break:normal;
-    white-space:pre;
-    background:transparent;
-    border:0
-}
+.markdown-body pre,
 .markdown-body .highlight {
-    margin-bottom:16px
+  background: #f8f8f8;
+  margin: 15px 0;
+  padding: 15px 20px;
+  border-style: solid;
+  border-color: #eef1f8;
+  border-width: 1px 0;
+  overflow: auto;
+  color: #4d4d4c;
+  line-height: 22.400000000000002px;
+}
+.markdown-body .highlight .gutter pre,
+.markdown-body .gist .gist-file .gist-data .line-numbers {
+  color: #666;
+  font-size: 0.85em;
+}
+.markdown-body pre,
+.markdown-body code {
+  font-family: "Source Code Pro", Consolas, Monaco, Menlo, Consolas, monospace;
+}
+.markdown-body code {
+  background: rgba(208,211,248,0.2);
+  color: #333;
+  padding: 0 0.3em;
+}
+.markdown-body pre code {
+  background: none;
+  text-shadow: none;
+  padding: 0;
 }
 .markdown-body .highlight pre {
-    margin-bottom:0;
-    word-break:normal
+  border: none;
+  margin: 0;
+  padding: 0;
 }
-.markdown-body .highlight pre,.markdown-body pre {
-    padding:16px;
-    overflow:auto;
-    font-size:85%;
-    line-height:1.45;
-    background-color:#f7f7f7;
-    border-radius:3px
+.markdown-body .highlight table {
+  margin: 0;
+  width: auto;
+  border: none;
 }
-.markdown-body pre code,.markdown-body pre tt {
-    display:inline;
-    max-width:auto;
-    padding:0;
-    margin:0;
-    overflow:visible;
-    line-height:inherit;
-    word-wrap:normal;
-    background-color:transparent;
-    border:0
+.markdown-body .highlight td {
+  border: none;
+  padding: 0;
 }
-.markdown-body pre code::before,.markdown-body pre code::after,.markdown-body pre tt::before,.markdown-body pre tt::after {
-    content:normal
+.markdown-body .highlight figcaption {
+  font-size: 0.85em;
+  color: #8e908c;
+  line-height: 1em;
+  margin-bottom: 1em;
+}
+.markdown-body .highlight figcaption:before,
+.markdown-body .highlight figcaption:after {
+  content: "";
+  display: table;
+}
+.markdown-body .highlight figcaption:after {
+  clear: both;
+}
+.markdown-body .highlight figcaption a {
+  float: right;
+}
+.markdown-body .highlight .gutter pre {
+  text-align: right;
+  padding-right: 20px;
+}
+.markdown-body .highlight .line {
+  height: 22.400000000000002px;
+}
+.markdown-body .highlight .line.marked {
+  background: #d6d6d6;
+}
+.markdown-body .gist {
+  margin: 0 -20px;
+  border-style: solid;
+  border-color: #eef1f8;
+  border-width: 1px 0;
+  background: #f8f8f8;
+  padding: 15px 20px 15px 0;
+}
+.markdown-body .gist .gist-file {
+  border: none;
+  font-family: "Source Code Pro", Consolas, Monaco, Menlo, Consolas, monospace;
+  margin: 0;
+}
+.markdown-body .gist .gist-file .gist-data {
+  background: none;
+  border: none;
+}
+.markdown-body .gist .gist-file .gist-data .line-numbers {
+  background: none;
+  border: none;
+  padding: 0 20px 0 0;
+}
+.markdown-body .gist .gist-file .gist-data .line-data {
+  padding: 0 !important;
+}
+.markdown-body .gist .gist-file .highlight {
+  margin: 0;
+  padding: 0;
+  border: none;
+}
+.markdown-body .gist .gist-file .gist-meta {
+  background: #f8f8f8;
+  color: #8e908c;
+  font: 0.85em -apple-system, "Arial", BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
+  text-shadow: 0 0;
+  padding: 0;
+  margin-top: 1em;
+  margin-left: 20px;
+}
+.markdown-body .gist .gist-file .gist-meta a {
+  color: color-link;
+  font-weight: normal;
+}
+.markdown-body .gist .gist-file .gist-meta a:hover {
+  text-decoration: underline;
+}
+pre .comment,
+pre .title {
+  color: #8e908c;
+}
+pre .variable,
+pre .attribute,
+pre .tag,
+pre .regexp,
+pre .ruby .constant,
+pre .xml .tag .title,
+pre .xml .pi,
+pre .xml .doctype,
+pre .html .doctype,
+pre .css .id,
+pre .css .class,
+pre .css .pseudo {
+  color: #c82829;
+}
+pre .number,
+pre .preprocessor,
+pre .built_in,
+pre .literal,
+pre .params,
+pre .constant {
+  color: #fb6d19;
+}
+pre .class,
+pre .ruby .class .title,
+pre .css .rules .attribute {
+  color: #718c00;
+}
+pre .string,
+pre .value,
+pre .inheritance,
+pre .header,
+pre .ruby .symbol,
+pre .xml .cdata {
+  color: #718c00;
+}
+pre .css .hexcolor {
+  color: #3e999f;
+}
+pre .function,
+pre .python .decorator,
+pre .python .title,
+pre .ruby .function .title,
+pre .ruby .title .keyword,
+pre .perl .sub,
+pre .javascript .title,
+pre .coffeescript .title {
+  color: #4271ae;
+}
+pre .keyword,
+pre .javascript .function {
+  color: #8959a8;
+}
+pre {
+  color: #525252;
+}
+pre .function .keyword,
+pre .constant {
+  color: #0092db;
+}
+pre .keyword,
+pre .attribute {
+  color: #e96900;
+}
+pre .number,
+pre .literal {
+  color: #ae81ff;
+}
+pre .tag,
+pre .tag .title,
+pre .change,
+pre .winutils,
+pre .flow,
+pre .lisp .title,
+pre .clojure .built_in,
+pre .nginx .title,
+pre .tex .special {
+  color: #2973b7;
+}
+pre .symbol,
+pre .symbol .string,
+pre .value,
+pre .regexp {
+  color: #42b983;
+}
+pre .title {
+  color: #83b917;
+}
+pre .tag .value,
+pre .string,
+pre .subst,
+pre .haskell .type,
+pre .preprocessor,
+pre .ruby .class .parent,
+pre .built_in,
+pre .sql .aggregate,
+pre .django .template_tag,
+pre .django .variable,
+pre .smalltalk .class,
+pre .javadoc,
+pre .django .filter .argument,
+pre .smalltalk .localvars,
+pre .smalltalk .array,
+pre .attr_selector,
+pre .pseudo,
+pre .addition,
+pre .stream,
+pre .envvar,
+pre .apache .tag,
+pre .apache .cbracket,
+pre .tex .command,
+pre .prompt {
+  color: #42b983;
+}
+pre .comment,
+pre .java .annotation,
+pre .python .decorator,
+pre .template_comment,
+pre .pi,
+pre .doctype,
+pre .shebang,
+pre .apache .sqbracket,
+pre .tex .formula {
+  color: #b3b3b3;
+}
+pre .deletion {
+  color: #ba4545;
+}
+pre .coffeescript .javascript,
+pre .javascript .xml,
+pre .tex .formula,
+pre .xml .javascript,
+pre .xml .vbscript,
+pre .xml .css,
+pre .xml .cdata {
+  opacity: 0.5;
 }
 .night-mode .markdown-body h2 {
     border-color:#2f2f2f


### PR DESCRIPTION
自带的高亮真的不好看，在群友的请求下我帮他移植了别的主题的高亮主题。
本来还可以尝试使用highlight.js，这样可以实现多个高亮主题随意切换，而且比较方便。
我嫌麻烦没弄，现在的高亮比原版的要好点，将就用吧。